### PR TITLE
feat: add duplicate connection action

### DIFF
--- a/App/AppModel.swift
+++ b/App/AppModel.swift
@@ -255,6 +255,41 @@ final class AppModel: ObservableObject {
         insertNew(node)
     }
 
+    func duplicateNode(_ node: MRNGNode) {
+        let copied = node.deepCopy(name: duplicateName(for: node))
+        if let parent = node.parent {
+            let idx = parent.children.firstIndex { $0 === node } ?? parent.children.count - 1
+            parent.addChild(copied, at: idx + 1)
+            expandedIDs.insert(parent.id)
+        } else {
+            let idx = doc?.roots.firstIndex { $0 === node } ?? ((doc?.roots.count ?? 1) - 1)
+            doc?.roots.insert(copied, at: min(idx + 1, doc?.roots.count ?? 0))
+            copied.parent = nil
+        }
+        if copied.isContainer {
+            expandedIDs.insert(copied.id)
+        }
+        selectedNodeID = copied.id
+        markDirty()
+    }
+
+    private func duplicateName(for node: MRNGNode) -> String {
+        let base = String(format: t("Connection.CopyNameFormat"), node.name)
+        let siblingNames: Set<String>
+        if let parent = node.parent {
+            siblingNames = Set(parent.children.map(\.name))
+        } else {
+            siblingNames = Set(doc?.roots.map(\.name) ?? [])
+        }
+        guard siblingNames.contains(base) else { return base }
+        var index = 2
+        while true {
+            let candidate = String(format: t("Connection.CopyNameNumberedFormat"), node.name, index)
+            if !siblingNames.contains(candidate) { return candidate }
+            index += 1
+        }
+    }
+
     private func insertNew(_ node: MRNGNode) {
         if let parent = targetContainer() {
             parent.addChild(node)
@@ -270,7 +305,7 @@ final class AppModel: ObservableObject {
         // Close any open sessions on this node or any of its descendants.
         let ids = Set([node] + descendants(of: node))
         sessions.filter { ids.contains($0.node) }.forEach { closeSession($0.id) }
-        if let parent = node.parent {
+        if node.parent != nil {
             node.removeFromParent()
         } else {
             doc?.roots.removeAll { $0 === node }

--- a/App/ContentView.swift
+++ b/App/ContentView.swift
@@ -265,6 +265,7 @@ struct TreeRow: View {
             }
             Button(t("Context.NewConnectionHere")) { model.selectedNodeID = node.id; model.addConnection() }
             Button(t("Context.NewFolderHere")) { model.selectedNodeID = node.id; model.addFolder() }
+            Button(t("Context.Duplicate")) { model.duplicateNode(node) }
             Divider()
             Button(t("Context.Delete"), role: .destructive) { model.pendingDelete = node }
         }

--- a/App/Resources/en.lproj/Localizable.strings
+++ b/App/Resources/en.lproj/Localizable.strings
@@ -53,6 +53,7 @@
 "Context.ExternalToolsSubmenu" = "External tools";
 "Context.NewConnectionHere" = "New connection here";
 "Context.NewFolderHere" = "New folder here";
+"Context.Duplicate" = "Duplicate";
 "Context.Delete" = "Delete";
 "Context.Reconnect" = "Reconnect";
 "Context.Disconnect" = "Disconnect";
@@ -106,6 +107,8 @@
 /* Connection / save */
 "Connection.NewConnectionName" = "New connection";
 "Connection.NewFolderName" = "New folder";
+"Connection.CopyNameFormat" = "%@ copy";
+"Connection.CopyNameNumberedFormat" = "%@ copy %d";
 "Connection.SaveButton" = "Save changes";
 "Connection.Saved" = "Saved";
 "Connection.Connect" = "Connect";

--- a/App/Resources/ro.lproj/Localizable.strings
+++ b/App/Resources/ro.lproj/Localizable.strings
@@ -48,6 +48,7 @@
 "Context.ExternalToolsSubmenu" = "Unelte externe";
 "Context.NewConnectionHere" = "Conexiune noua aici";
 "Context.NewFolderHere" = "Folder nou aici";
+"Context.Duplicate" = "Duplica";
 "Context.Delete" = "Sterge";
 "Context.Reconnect" = "Reconecteaza";
 "Context.Disconnect" = "Deconecteaza";
@@ -101,6 +102,8 @@
 /* Conexiune / salvare */
 "Connection.NewConnectionName" = "Conexiune noua";
 "Connection.NewFolderName" = "Folder nou";
+"Connection.CopyNameFormat" = "%@ copie";
+"Connection.CopyNameNumberedFormat" = "%@ copie %d";
 "Connection.SaveButton" = "Salveaza modificarile";
 "Connection.Saved" = "Salvat";
 "Connection.Connect" = "Conecteaza";

--- a/Sources/MRNGCore/Model.swift
+++ b/Sources/MRNGCore/Model.swift
@@ -52,6 +52,22 @@ public final class MRNGNode: Identifiable, Hashable {
         attributes[key] = value
     }
 
+    public func deepCopy(name: String? = nil) -> MRNGNode {
+        var copiedAttributes = attributes
+        let copiedName = name ?? self.name
+        copiedAttributes["Name"] = copiedName
+        let copied = MRNGNode(
+            id: UUID().uuidString.lowercased(),
+            name: copiedName,
+            isContainer: isContainer,
+            attributes: copiedAttributes
+        )
+        for child in children {
+            copied.addChild(child.deepCopy())
+        }
+        return copied
+    }
+
     // MARK: - Factories for new nodes (with mRemoteNG default attributes)
 
     public static func makeConnection(name: String, protocolType: String = "RDP",


### PR DESCRIPTION
Summary
Adds a Duplicate action to the connection tree context menu.

Details
- Copies an existing connection or folder with a fresh node ID.
- Preserves all connection attributes.
- Inserts the copy directly below the original.
- Adds localized menu/name strings.

Tested by running the application 