### PR TITLE
Fix sidebar context menu when no node is selected

### DIFF
--- a/App/AppModel.swift
+++ b/App/AppModel.swift
@@ -242,7 +242,7 @@ final class AppModel: ObservableObject {
         if let sel = node(byID: selectedNodeID) {
             return sel.isContainer ? sel : sel.parent
         }
-        return doc?.roots.first
+        return nil
     }
 
     func addConnection() {

--- a/App/ContentView.swift
+++ b/App/ContentView.swift
@@ -117,6 +117,16 @@ struct ContentView: View {
                 .scrollContentBackground(.hidden)
                 .environment(\.defaultMinListRowHeight, model.rowHeight)
                 .searchable(text: $model.searchText, placement: .sidebar, prompt: Text(t("Search.Placeholder")))
+                .contextMenu {
+                    Button(t("Toolbar.NewConnection")) {
+                        model.selectedNodeID = nil
+                        model.addConnection()
+                    }
+                    Button(t("Toolbar.NewFolder")) {
+                        model.selectedNodeID = nil
+                        model.addFolder()
+                    }
+                }
                 .frame(maxHeight: .infinity)
 
                 // Read-only status bar with Host/User/Pass + click-to-copy.


### PR DESCRIPTION
When right-clicking the empty area below the sidebar tree, creating a new connection or folder did not work correctly because the first root node was implicitly used as the parent.

This change makes selectedParent() return nil when no node is selected and adds a context menu to the sidebar background, allowing users to create new top-level connections and folders from empty space.

Tested locally on macOS by creating connections and folders from both selected nodes and the empty sidebar area.